### PR TITLE
future proofing ez-zarr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ authors = [
 maintainers = [
     { name = "Michael Stadler", email = "michael.stadler@fmi.ch" }
 ]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/tests/test_hcs_wrappers.py
+++ b/tests/test_hcs_wrappers.py
@@ -238,7 +238,7 @@ def test_get_table(plate_2d: hcs_wrappers.FractalZarr):
     assert 'well' in ann.obs
     df2 = plate_2d.get_table('FOV_ROI_table', include_wells=['B03'], as_AnnData=False)
     # make windows paths normal
-    df2['well'] = df2['well'].str.replace("\\", "")
+    df2.loc[:, 'well'] = df2['well'].str.replace("\\", "")
     assert df.equals(df2)
 
 def test_get_image_ROI_3d(plate_3d: hcs_wrappers.FractalZarr):

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -1109,8 +1109,8 @@ def test_imagelist_plot(imgL2: ome_zarr.ImageList, tmpdir: str):
     """Test `ome_zarr.ImageList.plot`."""
 
     imgL3 = imgL2
-    imgL3.layout['row_index'] = [1, 1]
-    imgL3.layout['column_index'] = [1, 1]
+    imgL3.layout.loc[:, 'row_index'] = [1, 1]
+    imgL3.layout.loc[:, 'column_index'] = [1, 1]
     with pytest.raises(Exception) as e_info:
         imgL3.plot()
     

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -1109,7 +1109,7 @@ def test_imagelist_plot(imgL2: ome_zarr.ImageList, tmpdir: str):
     """Test `ome_zarr.ImageList.plot`."""
 
     imgL3 = imgL2
-    imgL3.layout['row_index'] = [1, 1]
+    imgL3.layout.loc[:, 'row_index'] = [1, 1]
     imgL3.layout['column_index'] = [1, 1]
     with pytest.raises(Exception) as e_info:
         imgL3.plot()


### PR DESCRIPTION
These are a few changes that will keep `ez-zarr` functioning with future version of

- python (changes to the `pyproject.toml` file format, specifically related to how the license is specified, see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)
- pandas v3.0, which will change copy-on-write behavior when assigning values to a data frame (see chained assignments: https://pandas.pydata.org/docs/user_guide/copy_on_write.html#copy-on-write-chained-assignment).

Maybe worth before merging this:

- [x] should we bump the version?
- [x] are there any other maintenance tasks to do?
