### PR TITLE
add argument `label_pyramid_level` to plot method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ez_zarr"
-version = "0.4.1"
+version = "0.4.2"
 description = "Give easy, high-level access to ome-zarr filesets."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/src/ez_zarr/__init__.py
+++ b/src/ez_zarr/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 __author__ = 'Silvia Barbiero, Michael Stadler, Charlotte Soneson'

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -911,6 +911,17 @@ def test_plot(img2d: ome_zarr.Image, img4d: ome_zarr.Image, img3dv3: ome_zarr.Im
                        label_value=3,
                        extend_pixels=8)
         
+        # ... select label_pyramid_level
+        img2d.plot(label_name='organoids',
+                   label_value=3,
+                   label_pyramid_level='0',
+                   restrict_to_label_values=[3])
+        with pytest.raises(Exception) as e_info:
+            img2d.plot(upper_left_yx=(0, 0),
+                       label_value=3,
+                       label_pyramid_level='does-not-exist',
+                       restrict_to_label_values=[3])
+        
         # ... restrict plotting to label_value
         img2d.plot(label_name='organoids',
                    label_value=3,


### PR DESCRIPTION
By default, the lowest-resolution pyramid level is selected to calculate the bounding box for a given `label_value`, which is the fastest but may result in inaccurate bounding boxes.

The new argument allows the user to select an appropriate pyramid level if needed.